### PR TITLE
add ForceProposeConfChange to Node interface

### DIFF
--- a/raft/node.go
+++ b/raft/node.go
@@ -186,6 +186,8 @@ type Node interface {
 	// failure in snapshot sending is caught and reported back to the leader; so it can resume raft
 	// log probing in the follower.
 	ReportSnapshot(id uint64, status SnapshotStatus)
+
+	ForceProposeConfChange(ctx context.Context, cc pb.ConfChange) error
 	// Stop performs any necessary termination of the Node.
 	Stop()
 }


### PR DESCRIPTION
error in `go-pttai`: 

```
me/protocol_raft.go:214:15: pm.raftNode.ForceProposeConfChange undefined (type raft.Node has no field or method ForceProposeConfChange)
```